### PR TITLE
chore(deps): bump https://github.com/nxmatic/jxlabs-nos-jx.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [nxmatic/jx](https://github.com/nxmatic/jx.git) |  | []() | 
+[nxmatic/jxlabs-nos-jx](https://github.com/nxmatic/jxlabs-nos-jx.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/nxmatic/jx.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: nxmatic
+  repo: jxlabs-nos-jx
+  url: https://github.com/nxmatic/jxlabs-nos-jx.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/nxmatic-jxlabs-nos-jx-sr.yaml
+++ b/repositories/templates/nxmatic-jxlabs-nos-jx-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: nxmatic
+    provider: github
+    repository: jxlabs-nos-jx
+  name: nxmatic-jxlabs-nos-jx
+spec:
+  description: Imported application for nxmatic/jxlabs-nos-jx
+  httpCloneURL: https://github.com/nxmatic/jxlabs-nos-jx.git
+  org: nxmatic
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jxlabs-nos-jx
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:nxmatic/jxlabs-nos-jx


### PR DESCRIPTION
Update [nxmatic/jxlabs-nos-jx](https://github.com/nxmatic/jxlabs-nos-jx.git) 

Command run was `jx import --git-username=nxmatic --git-api-token=db50ae0fa06568bd516ba879c080fd84ce7646d7 --git-provider-url=https://github.com --no-draft --no-jenkinsfile`