### PR TITLE
chore(deps): bump https://github.com/nxmatic/jxlabs-nos-helmboot.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,3 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [nxmatic/jx](https://github.com/nxmatic/jx.git) |  | []() | 
 [nxmatic/jxlabs-nos-jx](https://github.com/nxmatic/jxlabs-nos-jx.git) |  | []() | 
+[nxmatic/jxlabs-nos-helmboot](https://github.com/nxmatic/jxlabs-nos-helmboot.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -11,3 +11,9 @@ dependencies:
   url: https://github.com/nxmatic/jxlabs-nos-jx.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: nxmatic
+  repo: jxlabs-nos-helmboot
+  url: https://github.com/nxmatic/jxlabs-nos-helmboot.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/nxmatic-jxlabs-nos-helmboot-sr.yaml
+++ b/repositories/templates/nxmatic-jxlabs-nos-helmboot-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: nxmatic
+    provider: github
+    repository: jxlabs-nos-helmboot
+  name: nxmatic-jxlabs-nos-helmboot
+spec:
+  description: Imported application for nxmatic/jxlabs-nos-helmboot
+  httpCloneURL: https://github.com/nxmatic/jxlabs-nos-helmboot.git
+  org: nxmatic
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jxlabs-nos-helmboot
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:nxmatic/jxlabs-nos-helmboot


### PR DESCRIPTION
Update [nxmatic/jxlabs-nos-helmboot](https://github.com/nxmatic/jxlabs-nos-helmboot.git) 

Command run was `jx import --git-username=nxmatic --git-api-token=db50ae0fa06568bd516ba879c080fd84ce7646d7 --git-provider-url=https://github.com --no-draft --no-jenkinsfile`